### PR TITLE
Create refresh commits via GraphQL API to satisfy signature ruleset

### DIFF
--- a/.github/workflows/build-profile.yml
+++ b/.github/workflows/build-profile.yml
@@ -31,10 +31,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run --project generator python generator/build.py
 
-      - name: Commit and push if changed
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md assets/
-          git diff --cached --quiet || git commit -m "chore: refresh profile dashboard"
-          git push
+      # The ruleset on main requires verified signatures, which rejects plain
+      # `git push` from Actions. createCommitOnBranch commits are signed by
+      # GitHub, so the refresh lands with a Verified badge instead.
+      - name: Commit via API if changed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uv run --project generator python generator/api_commit.py

--- a/generator/api_commit.py
+++ b/generator/api_commit.py
@@ -1,0 +1,101 @@
+"""Create the dashboard refresh commit on GitHub via GraphQL.
+
+Plain `git push` from Actions is rejected by the repository ruleset that
+requires verified commit signatures on main. Commits created with the
+GraphQL `createCommitOnBranch` mutation are signed by GitHub automatically,
+so the daily refresh satisfies the rule without managing signing keys.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GRAPHQL_URL = "https://api.github.com/graphql"
+TRACKED_PATHS = ("README.md", "assets/")
+COMMIT_HEADLINE = "chore: refresh profile dashboard"
+
+MUTATION = """
+mutation ($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit { oid url }
+  }
+}
+"""
+
+
+def plan_changes(porcelain: str) -> dict:
+    """Map `git status --porcelain` output to GraphQL fileChanges.
+
+    Paths are assumed not to contain spaces or quoting (true for this
+    repo's README.md and assets/*.svg outputs).
+    """
+    additions: list[dict] = []
+    deletions: list[dict] = []
+    for line in porcelain.splitlines():
+        if not line.strip():
+            continue
+        status, path = line[:2], line[3:].strip()
+        if status.strip().startswith("D"):
+            deletions.append({"path": path})
+        else:
+            additions.append({"path": path})
+    return {"additions": additions, "deletions": deletions}
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def main() -> int:
+    changes = plan_changes(_git("status", "--porcelain", "--", *TRACKED_PATHS))
+    if not (changes["additions"] or changes["deletions"]):
+        print("no changes to commit")
+        return 0
+    for addition in changes["additions"]:
+        raw = (REPO_ROOT / addition["path"]).read_bytes()
+        addition["contents"] = base64.b64encode(raw).decode()
+    payload = {
+        "query": MUTATION,
+        "variables": {
+            "input": {
+                "branch": {
+                    "repositoryNameWithOwner": os.environ["GITHUB_REPOSITORY"],
+                    "branchName": os.environ.get("GITHUB_REF_NAME", "main"),
+                },
+                "message": {"headline": COMMIT_HEADLINE},
+                "expectedHeadOid": _git("rev-parse", "HEAD").strip(),
+                "fileChanges": changes,
+            }
+        },
+    }
+    resp = httpx.post(
+        GRAPHQL_URL,
+        json=payload,
+        headers={"Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    if body.get("errors"):
+        print(f"error: {body['errors']}", file=sys.stderr)
+        return 1
+    commit = body["data"]["createCommitOnBranch"]["commit"]
+    print(f"created signed commit {commit['oid'][:9]}: {commit['url']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_api_commit.py
+++ b/tests/test_api_commit.py
@@ -1,0 +1,22 @@
+from generator.api_commit import plan_changes
+
+
+def test_plan_changes_maps_modified_added_and_deleted():
+    porcelain = (
+        " M README.md\n"
+        " M assets/hero.svg\n"
+        " D assets/old-tile.svg\n"
+        "?? assets/new-tile.svg\n"
+    )
+    changes = plan_changes(porcelain)
+    assert {a["path"] for a in changes["additions"]} == {
+        "README.md",
+        "assets/hero.svg",
+        "assets/new-tile.svg",
+    }
+    assert changes["deletions"] == [{"path": "assets/old-tile.svg"}]
+
+
+def test_plan_changes_empty_output_means_no_changes():
+    assert plan_changes("") == {"additions": [], "deletions": []}
+    assert plan_changes("\n") == {"additions": [], "deletions": []}


### PR DESCRIPTION
## Problem

The first on-main run of **Build profile** failed at the push step:

`GH013: Repository rule violations — Commits must have verified signatures.`

The repo ruleset on `main` requires signed commits, and `github-actions[bot]`'s plain `git commit && git push` produces unsigned ones.

## Fix

Replace the git push step with `generator/api_commit.py`, which creates the refresh commit through GitHub's GraphQL `createCommitOnBranch` mutation. API-created commits are **signed by GitHub automatically** (Verified badge) — no key management, no ruleset bypass.

- Detects changed files under `README.md` + `assets/` from `git status --porcelain`
- No changes → exits 0 quietly (same semantics as before)
- Handles additions and deletions; `expectedHeadOid` guards against races
- Unit-tested porcelain parsing (suite now 30 tests)

## Verification plan

After merge: trigger **Actions → Build profile → Run workflow** and confirm the refresh commit lands green with a Verified badge.